### PR TITLE
feat(branchsync): enable poller config + deactivate branches absent from source

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,3 +23,19 @@ OTEL_ENDPOINT=localhost:4317
 
 # Diagnostics (optional)
 DIAGNOSTIC_SECRET=
+
+# Branch projection sync (optional) — pulls branches from core7-service-enterprise
+# into auth7.branches. Poller stays dormant unless BOTH ENTERPRISE_SOURCE_URL and
+# ENTERPRISE_CLIENT_ID are set. Secrets via env only — never in config files.
+# When enabled, a full error-free pass also deactivates (is_active=false) any
+# branch the source no longer reports; auth7.branches is a projection, not master.
+ENTERPRISE_SOURCE_URL=http://core7-service-enterprise:8090/v1/source-contracts/branches
+ENTERPRISE_CLIENT_ID=branchsync
+ENTERPRISE_CLIENT_SECRET=replace-with-branchsync-m2m-secret
+# auth7 token endpoint for the client_credentials grant (default: http://localhost:4445/oauth2/token)
+AUTH7_TOKEN_URL=http://localhost:4445/oauth2/token
+# Tenant marker — written to branches.org_id and sent as X-Actor-Org-Id
+# (default: demo tenant 00000000-0000-0000-0000-000000000001)
+ENTERPRISE_TENANT_ORG_ID=00000000-0000-0000-0000-000000000001
+# Poll interval, Go duration syntax (default: 5m)
+ENTERPRISE_POLL_INTERVAL=5m

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -31,7 +31,7 @@ Diturunkan dari "Out of Scope v1.0" di [`specs/00-overview.md`](./specs/00-overv
 
 | Item | Butuh kontrak dari | Kondisi sekarang |
 |---|---|---|
-| Runtime **branch projection** sync | `core7-service-enterprise` (S3) — endpoint `/v1/source-contracts/branches` final & stabil | **Sebagian SUDAH ADA**: `internal/service/branchsync/poller.go` HTTP poller (M2M, 5-min, upsert 5 kolom) ter-wire di `cmd/server/start.go`, tapi **dorman** (aktif hanya bila `ENTERPRISE_SOURCE_URL`+`ENTERPRISE_CLIENT_ID` di-set). Script manual = fallback. Belum: NATS push, drift/delete handling, hierarchy/type |
+| Runtime **branch projection** sync | `core7-service-enterprise` (S3) — endpoint `/v1/source-contracts/branches` final & stabil | **SUDAH ADA (S3.1, #157)**: `internal/service/branchsync/poller.go` HTTP poller (M2M, 5-min, upsert 5 kolom) ter-wire di `cmd/server/start.go`. Enable via env (`ENTERPRISE_SOURCE_URL`+`ENTERPRISE_CLIENT_ID`, lihat `.env.example` + spec 09 §4.5.4). **Delete/tombstone handling**: pass sukses-penuh men-deactivate branch yang absen dari source, dengan guard partial-fetch + empty-set. Belum: NATS push, hierarchy/type (out of scope projection) |
 | Runtime sync **employee reference** (employee_id, department, position, branch_code) sebagai attribute (bukan master) | `core7-service-enterprise` (S3) — kontrak employee reference | Belum ada (tidak dimodelkan di auth7) |
 | Cache/event consumer **policy7** parameter context untuk ABAC input | `policy7` — kontrak parameter (tanpa memindahkan policy truth ke auth7) | Belum ada (OPA `opacache` ada, tapi belum ada consumer parameter policy7) |
 

--- a/docs/specs/09-integration.md
+++ b/docs/specs/09-integration.md
@@ -416,6 +416,39 @@ Agar wiring runtime bisa dimulai di Wave 3, auth7 membutuhkan finalisasi dari st
 - definisi final schema contract employee reference dari `core7-service-enterprise`
 - konfirmasi caller context policy input yang dipakai auth7 dari `policy7`
 
+### 4.5.4 Branch Sync Poller — Enable & Operations (Wave S3.1)
+
+Runtime consumer dari kontrak 4.5.1 adalah `internal/service/branchsync/poller.go`, di-wire di
+`cmd/server/start.go`. Poller melakukan HTTP pull (M2M `client_credentials`) ke
+`GET /v1/source-contracts/branches`, paginasi semua halaman, lalu upsert 5 kolom projection
+(`id`, `org_id`, `branch_code`, `is_active`, `updated_at`) ke `auth7.branches`.
+
+**Enable** — poller dorman secara default; aktif hanya bila **kedua** `ENTERPRISE_SOURCE_URL`
+dan `ENTERPRISE_CLIENT_ID` di-set. Env vars (semua secret via env, jangan di config file):
+
+| Env var | Contoh / default | Keterangan |
+|---|---|---|
+| `ENTERPRISE_SOURCE_URL` | `http://core7-service-enterprise:8090/v1/source-contracts/branches` | Endpoint source contract. Kosong → poller mati. |
+| `ENTERPRISE_CLIENT_ID` | `branchsync` | Client M2M terdaftar di auth7. Kosong → poller mati. |
+| `ENTERPRISE_CLIENT_SECRET` | *(secret)* | Secret untuk grant `client_credentials`. |
+| `AUTH7_TOKEN_URL` | `http://localhost:4445/oauth2/token` | Token endpoint auth7. |
+| `ENTERPRISE_TENANT_ORG_ID` | `00000000-0000-0000-0000-000000000001` | Tenant marker → `branches.org_id` + header `X-Actor-Org-Id`. |
+| `ENTERPRISE_POLL_INTERVAL` | `5m` | Interval poll (Go duration). |
+
+**Delete / tombstone semantics** — `auth7.branches` adalah **projection**, bukan master;
+lifecycle dimiliki enterprise. Maka:
+- Setiap pass yang **sukses penuh** (semua halaman ter-fetch tanpa error) mengumpulkan set
+  semua branch ID dari source, lalu men-deactivate (`is_active=false`) branch yang **tidak lagi**
+  dilaporkan source untuk tenant tsb.
+- **Guard partial fetch**: jika ada satu halaman gagal, `tick()` return early — tidak ada
+  deactivation. Sehingga outage enterprise sementara tidak pernah menghapus projection.
+- **Guard empty set**: pass sukses yang melaporkan 0 branch diperlakukan no-op (bukan "semua
+  branch dihapus") untuk mencegah projection ter-wipe akibat misconfiguration.
+- `is_active=false` dari source juga dihormati (branch di-deactivate, bukan sekadar di-skip).
+
+Hierarchy/type (`parent_enterprise_branch_id`, `branch_type_code`) **di luar scope** poller saat
+ini — tetap di domain enterprise.
+
 ### 4.6 service7-template
 
 ```

--- a/internal/service/branchsync/poller.go
+++ b/internal/service/branchsync/poller.go
@@ -152,11 +152,20 @@ type contractEnvelope struct {
 
 // tick performs one full fetch + upsert cycle, paginating until all pages
 // are read.  Returns the first error encountered or nil if successful.
+//
+// auth7.branches is a projection, NOT master data — the enterprise domain
+// owns the lifecycle.  So a full, error-free pass also tombstones (sets
+// is_active=false) any branch that no longer appears in the source.  The
+// deactivation runs ONLY after every page fetched OK: if any page errors we
+// return early and leave existing rows untouched, so a transient enterprise
+// outage can never wipe the projection.
 func (p *Poller) tick(ctx context.Context) error {
 	const op = "branchsync.Poller.tick"
 
 	page := 1
 	totalApplied := 0
+	// seen accumulates every branch ID returned across all pages of this pass.
+	seen := make(map[uuid.UUID]struct{})
 
 	for {
 		env, err := p.fetchPage(ctx, page)
@@ -166,7 +175,7 @@ func (p *Poller) tick(ctx context.Context) error {
 		if len(env.Data) == 0 {
 			break
 		}
-		applied, err := p.upsertBatch(ctx, env.Data)
+		applied, err := p.upsertBatch(ctx, env.Data, seen)
 		if err != nil {
 			return fmt.Errorf("%s upsert page=%d: %w", op, page, err)
 		}
@@ -177,8 +186,16 @@ func (p *Poller) tick(ctx context.Context) error {
 		page++
 	}
 
+	// Full pass succeeded (no early return above) — reconcile deletions.
+	deactivated, err := p.deactivateAbsent(ctx, seen)
+	if err != nil {
+		return fmt.Errorf("%s deactivate: %w", op, err)
+	}
+
 	p.logger.Info().Str("op", op).
 		Int("applied", totalApplied).
+		Int("seen", len(seen)).
+		Int("deactivated", deactivated).
 		Msg("branch sync complete")
 	return nil
 }
@@ -219,8 +236,10 @@ func (p *Poller) fetchPage(ctx context.Context, page int) (*contractEnvelope, er
 
 // upsertBatch performs the UPSERT for the items in a single page using a tx.
 // Only the 5 projection columns are stored — branch hierarchy and type live
-// in the enterprise domain.
-func (p *Poller) upsertBatch(ctx context.Context, items []branchProjectionItem) (int, error) {
+// in the enterprise domain.  Every successfully-parsed branch ID (regardless
+// of its active status) is recorded in seen so the caller can tombstone the
+// branches that the source no longer reports.
+func (p *Poller) upsertBatch(ctx context.Context, items []branchProjectionItem, seen map[uuid.UUID]struct{}) (int, error) {
 	const op = "branchsync.Poller.upsertBatch"
 
 	tx, err := p.pool.Begin(ctx)
@@ -236,6 +255,9 @@ func (p *Poller) upsertBatch(ctx context.Context, items []branchProjectionItem) 
 			p.logger.Warn().Str("branch_id", item.BranchID).Err(err).Msg("skip — invalid uuid")
 			continue
 		}
+		seen[id] = struct{}{}
+		// Honor is_active=false from the source — a branch reported as
+		// non-active is deactivated here, not merely skipped.
 		isActive := strings.EqualFold(item.Status, "active")
 
 		_, err = tx.Exec(ctx, `
@@ -258,6 +280,48 @@ func (p *Poller) upsertBatch(ctx context.Context, items []branchProjectionItem) 
 		return applied, fmt.Errorf("%s commit: %w", op, err)
 	}
 	return applied, nil
+}
+
+// deactivateAbsent tombstones every still-active branch for this tenant that
+// the source did not report in the completed pass.  MUST be called only after
+// a fully successful fetch (see tick) — running it on a partial pass would
+// deactivate branches that merely live on an unfetched page.
+//
+// Guard: an empty seen set is treated as a no-op.  A successful pass that
+// returns zero branches almost always means a misconfigured source or an
+// upstream that briefly served an empty list — not "every branch was deleted".
+// Refusing to deactivate on empty avoids wiping the whole projection.
+func (p *Poller) deactivateAbsent(ctx context.Context, seen map[uuid.UUID]struct{}) (int, error) {
+	const op = "branchsync.Poller.deactivateAbsent"
+
+	if len(seen) == 0 {
+		p.logger.Warn().Str("op", op).
+			Msg("source returned zero branches — skipping deactivation to avoid wiping the projection")
+		return 0, nil
+	}
+
+	// Pass IDs as text[] and cast to uuid[] — robust under pgx's default type
+	// map without a registered uuid array codec.
+	ids := make([]string, 0, len(seen))
+	for id := range seen {
+		ids = append(ids, id.String())
+	}
+
+	tag, err := p.pool.Exec(ctx, `
+		UPDATE branches
+		SET is_active = false, updated_at = NOW()
+		WHERE org_id = $1 AND is_active = true AND id <> ALL($2::uuid[])
+	`, p.cfg.OrgID, ids)
+	if err != nil {
+		return 0, fmt.Errorf("%s: %w", op, err)
+	}
+
+	n := int(tag.RowsAffected())
+	if n > 0 {
+		p.logger.Info().Str("op", op).Int("deactivated", n).
+			Msg("tombstoned branches absent from source")
+	}
+	return n, nil
 }
 
 // getM2MToken fetches a short-lived bearer token from auth7 using the

--- a/internal/service/branchsync/poller_test.go
+++ b/internal/service/branchsync/poller_test.go
@@ -1,0 +1,54 @@
+package branchsync
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+)
+
+// TestDeactivateAbsent_EmptySeenIsNoOp is the critical safety guard: a
+// successful pass that reports zero branches must NOT touch the database,
+// otherwise a misconfigured source or a transient empty response would wipe
+// the whole projection. The nil pool proves no query is issued — if the guard
+// regressed, pool.Exec would panic on the nil receiver.
+func TestDeactivateAbsent_EmptySeenIsNoOp(t *testing.T) {
+	p := &Poller{
+		cfg:    Config{OrgID: uuid.MustParse("00000000-0000-0000-0000-000000000001")},
+		pool:   nil, // any DB access here would panic — that's the assertion
+		logger: zerolog.Nop(),
+	}
+
+	n, err := p.deactivateAbsent(context.Background(), map[uuid.UUID]struct{}{})
+	if err != nil {
+		t.Fatalf("expected nil error on empty seen set, got %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("expected 0 deactivations on empty seen set, got %d", n)
+	}
+}
+
+// TestNewPoller_EnabledGate verifies the poller only arms when both SourceURL
+// and ClientID are present.
+func TestNewPoller_EnabledGate(t *testing.T) {
+	cases := []struct {
+		name      string
+		sourceURL string
+		clientID  string
+		want      bool
+	}{
+		{"both set", "http://enterprise/branches", "branchsync", true},
+		{"missing url", "", "branchsync", false},
+		{"missing client", "http://enterprise/branches", "", false},
+		{"both empty", "", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := NewPoller(Config{SourceURL: tc.sourceURL, ClientID: tc.clientID}, nil, zerolog.Nop())
+			if p.enabled != tc.want {
+				t.Fatalf("enabled = %v, want %v", p.enabled, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #157. Ref: ihsansolusi/core7-devroot#601 · [Wave S3.1]

## What

Enables the dormant enterprise branch-projection poller and adds delete/tombstone reconciliation so a branch removed/deactivated in enterprise is reflected in `auth7.branches`.

### Changes
- **`internal/service/branchsync/poller.go`**
  - `tick()` collects every branch ID seen across **all pages** of a pass. After a **fully successful** pass it deactivates branches the source no longer reports:
    `UPDATE branches SET is_active=false, updated_at=NOW() WHERE org_id=$1 AND is_active=true AND id <> ALL($2::uuid[])`.
  - **Guard — partial fetch**: any page error → `tick()` returns early, no deactivation. A transient enterprise outage can never wipe the projection.
  - **Guard — empty set**: a successful pass reporting 0 branches is a no-op (treated as misconfig, not "all deleted").
  - Honor `is_active=false` from source (deactivate, not skip).
- **`.env.example` + `docs/specs/09-integration.md` §4.5.4 + `docs/ROADMAP.md`** — enable instructions + tombstone semantics documented. Secrets via env only.
- **`poller_test.go`** — unit tests for the empty-set guard (nil pool proves no query issued) and the enable gate.

Scope kept to the existing 5 projection columns; hierarchy/type out of scope.

## Test
```
go build ./...        # OK
go vet ./internal/service/branchsync/   # OK
go test ./...         # ok (branchsync tests pass; tests pkg ok)
```

## Pending (needs local env)
e2e verify with infra + enterprise running (add/deactivate a branch → reflected within ≤1 interval) — requires real M2M creds in this environment.