### PR TITLE
feat(authz): serve gRPC AuthCheckService (lib7 contract) [S3.3a-grpc #167]

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,3 +39,7 @@ AUTH7_TOKEN_URL=http://localhost:4445/oauth2/token
 ENTERPRISE_TENANT_ORG_ID=00000000-0000-0000-0000-000000000001
 # Poll interval, Go duration syntax (default: 5m)
 ENTERPRISE_POLL_INTERVAL=5m
+
+# gRPC AuthCheck PDP server (lib7 auth7grpc contract) for PEPs (workflow7, etc.).
+# Empty = disabled. PEPs set their auth7 gRPC client Addr to this host:port.
+AUTH7_GRPC_ADDRESS=:9090

--- a/cmd/server/start.go
+++ b/cmd/server/start.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 	"os/signal"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
+	"github.com/ihsansolusi/auth7/internal/api/grpc/authcheck"
 	"github.com/ihsansolusi/auth7/internal/api/rest"
 	"github.com/ihsansolusi/auth7/internal/infrastructure"
 	"github.com/ihsansolusi/auth7/internal/messaging/nats"
@@ -295,6 +297,31 @@ func runStart(cmd *cobra.Command, args []string) error {
 		primaryPool.Close()
 		return nil
 	})
+
+	// ─── gRPC AuthCheck PDP server ──────────────────────────────────────────
+	// Serves auth.v1.AuthCheckService (lib7 auth7grpc contract) for PEPs
+	// (workflow7, etc.). Disabled when AUTH7_GRPC_ADDRESS is empty.
+	if grpcAddr := os.Getenv("AUTH7_GRPC_ADDRESS"); grpcAddr != "" {
+		if authCheckSrv := rest.NewAuthCheckGRPCServer(deps); authCheckSrv != nil {
+			lis, lerr := net.Listen("tcp", grpcAddr)
+			if lerr != nil {
+				logger.Error().Err(lerr).Str("addr", grpcAddr).Msg("grpc authcheck listen failed")
+			} else {
+				grpcSrv := grpc.NewServer()
+				authcheck.Register(grpcSrv, authCheckSrv)
+				go func() {
+					logger.Info().Str("addr", grpcAddr).Msg("grpc AuthCheck PDP server listening")
+					if serr := grpcSrv.Serve(lis); serr != nil {
+						logger.Error().Err(serr).Msg("grpc authcheck server exited")
+					}
+				}()
+				sm.Register("grpc-authcheck", func(ctx context.Context) error {
+					grpcSrv.GracefulStop()
+					return nil
+				})
+			}
+		}
+	}
 
 	addr := fmt.Sprintf(":%d", cfg.Server.Port)
 	httpServer := &http.Server{

--- a/internal/api/grpc/authcheck/codec.go
+++ b/internal/api/grpc/authcheck/codec.go
@@ -1,0 +1,37 @@
+package authcheck
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"google.golang.org/grpc/encoding"
+)
+
+// init registers the JSON codec so this gRPC server can decode/encode the
+// "json" content-subtype used by lib7-service-go/auth7grpc clients. This mirrors
+// that client's codec exactly so auth7 serves the same wire contract WITHOUT
+// protobuf code generation.
+func init() {
+	encoding.RegisterCodec(jsonCodec{})
+}
+
+type jsonCodec struct{}
+
+func (jsonCodec) Marshal(v any) ([]byte, error) {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return nil, fmt.Errorf("authcheck: marshal: %w", err)
+	}
+	return data, nil
+}
+
+func (jsonCodec) Unmarshal(data []byte, v any) error {
+	if err := json.Unmarshal(data, v); err != nil {
+		return fmt.Errorf("authcheck: unmarshal: %w", err)
+	}
+	return nil
+}
+
+func (jsonCodec) Name() string { return "json" }
+
+var _ encoding.Codec = jsonCodec{}

--- a/internal/api/grpc/authcheck/server.go
+++ b/internal/api/grpc/authcheck/server.go
@@ -1,0 +1,125 @@
+// Package authcheck serves auth7's AuthCheckService over gRPC using a JSON codec
+// (no protobuf codegen), matching the lib7-service-go/auth7grpc client contract.
+// It is the gRPC transport for the PDP; the REST transport
+// (internal/api/rest internal_authz.go) shares the same decision core
+// (authz.PermissionChecker + authz.ResolveAuthContext).
+package authcheck
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"github.com/ihsansolusi/auth7/internal/service/authz"
+	"github.com/rs/zerolog"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// Wire types — JSON shape MUST match lib7-service-go/auth7grpc.
+type CheckPermissionRequest struct {
+	UserID     string `json:"user_id"`
+	Permission string `json:"permission"`
+	BranchID   string `json:"branch_id"`
+	OrgID      string `json:"org_id"`
+}
+
+type CheckPermissionResponse struct {
+	Allowed    bool        `json:"allowed"`
+	Reason     string      `json:"reason"`
+	FieldMasks []FieldMask `json:"field_masks"`
+}
+
+type FieldMask struct {
+	Field     string `json:"field"`
+	MaskValue string `json:"mask_value"`
+	Reason    string `json:"reason"`
+}
+
+// Server implements auth.v1.AuthCheckService.CheckPermission. It resolves the
+// user's effective permissions from auth7's own role data, then runs the shared
+// PermissionChecker (role-based + operational-hours time-gate).
+type Server struct {
+	userRoleSvc authz.UserRolesGetter
+	roleSvc     authz.RolePermsGetter
+	checker     *authz.PermissionChecker
+	logger      zerolog.Logger
+}
+
+func NewServer(userRoleSvc authz.UserRolesGetter, roleSvc authz.RolePermsGetter, checker *authz.PermissionChecker, logger zerolog.Logger) *Server {
+	return &Server{userRoleSvc: userRoleSvc, roleSvc: roleSvc, checker: checker, logger: logger}
+}
+
+func (s *Server) CheckPermission(ctx context.Context, req *CheckPermissionRequest) (*CheckPermissionResponse, error) {
+	userID, err := uuid.Parse(req.UserID)
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, "invalid user_id")
+	}
+	orgID, err := uuid.Parse(req.OrgID)
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, "invalid org_id")
+	}
+	branchID, err := uuid.Parse(req.BranchID)
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, "invalid branch_id")
+	}
+	if req.Permission == "" {
+		return nil, status.Error(codes.InvalidArgument, "permission required")
+	}
+
+	authCtx, err := authz.ResolveAuthContext(ctx, s.userRoleSvc, s.roleSvc, userID, orgID, branchID)
+	if err != nil {
+		s.logger.Error().Err(err).Str("user", req.UserID).Msg("authcheck resolve auth context failed")
+		return nil, status.Error(codes.Internal, "resolve auth context failed")
+	}
+
+	result, err := s.checker.CheckPermission(ctx, authCtx, req.Permission)
+	if err != nil {
+		s.logger.Error().Err(err).Str("permission", req.Permission).Msg("authcheck check permission failed")
+		return nil, status.Error(codes.Internal, "check permission failed")
+	}
+
+	masks := make([]FieldMask, 0, len(result.FieldMasks))
+	for _, m := range result.FieldMasks {
+		masks = append(masks, FieldMask{Field: m.Field, MaskValue: m.MaskValue, Reason: m.Reason})
+	}
+	return &CheckPermissionResponse{Allowed: result.Allowed, Reason: result.Reason, FieldMasks: masks}, nil
+}
+
+// ── manual gRPC service registration (no protobuf codegen) ──────────────────
+
+type authCheckService interface {
+	CheckPermission(context.Context, *CheckPermissionRequest) (*CheckPermissionResponse, error)
+}
+
+func checkPermissionHandler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(CheckPermissionRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(authCheckService).CheckPermission(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{Server: srv, FullMethod: "/auth.v1.AuthCheckService/CheckPermission"}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(authCheckService).CheckPermission(ctx, req.(*CheckPermissionRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+// serviceDesc matches the method path lib7-service-go/auth7grpc invokes:
+// "/auth.v1.AuthCheckService/CheckPermission".
+var serviceDesc = grpc.ServiceDesc{
+	ServiceName: "auth.v1.AuthCheckService",
+	HandlerType: (*authCheckService)(nil),
+	Methods: []grpc.MethodDesc{
+		{MethodName: "CheckPermission", Handler: checkPermissionHandler},
+	},
+	Streams:  []grpc.StreamDesc{},
+	Metadata: "auth/v1/auth.proto",
+}
+
+// Register registers the AuthCheckService on the given gRPC server.
+func Register(s *grpc.Server, impl *Server) {
+	s.RegisterService(&serviceDesc, impl)
+}

--- a/internal/api/grpc/authcheck/server_test.go
+++ b/internal/api/grpc/authcheck/server_test.go
@@ -1,0 +1,66 @@
+package authcheck
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/ihsansolusi/auth7/internal/domain"
+	"github.com/ihsansolusi/auth7/internal/service/authz"
+	"github.com/rs/zerolog"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+type fakeUserRoles struct{ roles []*domain.UserRole }
+
+func (f fakeUserRoles) GetUserRoles(_ interface{}, _ uuid.UUID) ([]*domain.UserRole, error) {
+	return f.roles, nil
+}
+
+type fakeRolePerms struct{ byRole map[uuid.UUID][]*domain.Permission }
+
+func (f fakeRolePerms) GetPermissions(_ interface{}, roleID uuid.UUID) ([]*domain.Permission, error) {
+	return f.byRole[roleID], nil
+}
+
+func newServer(roles []*domain.UserRole, perms map[uuid.UUID][]*domain.Permission) *Server {
+	return NewServer(
+		fakeUserRoles{roles: roles},
+		fakeRolePerms{byRole: perms},
+		authz.NewTimeGatedChecker(nil, nil), // no time-gate → role-based decision
+		zerolog.Nop(),
+	)
+}
+
+func TestGRPCCheckPermission(t *testing.T) {
+	org, branch, user, roleID := uuid.New(), uuid.New(), uuid.New(), uuid.New()
+	roles := []*domain.UserRole{{RoleID: roleID, OrgID: org, BranchID: nil}}
+	perms := map[uuid.UUID][]*domain.Permission{roleID: {{Code: "report:view"}}}
+	srv := newServer(roles, perms)
+
+	base := func(perm string) *CheckPermissionRequest {
+		return &CheckPermissionRequest{UserID: user.String(), OrgID: org.String(), BranchID: branch.String(), Permission: perm}
+	}
+
+	t.Run("granted → allowed", func(t *testing.T) {
+		resp, err := srv.CheckPermission(context.Background(), base("report:view"))
+		if err != nil || !resp.Allowed {
+			t.Fatalf("expected allowed, got allowed=%v err=%v", resp, err)
+		}
+	})
+
+	t.Run("ungranted → denied", func(t *testing.T) {
+		resp, err := srv.CheckPermission(context.Background(), base("transaction:create"))
+		if err != nil || resp.Allowed {
+			t.Fatalf("expected denied, got allowed=%v err=%v", resp, err)
+		}
+	})
+
+	t.Run("invalid user_id → InvalidArgument", func(t *testing.T) {
+		_, err := srv.CheckPermission(context.Background(), &CheckPermissionRequest{UserID: "nope", OrgID: org.String(), BranchID: branch.String(), Permission: "x"})
+		if status.Code(err) != codes.InvalidArgument {
+			t.Fatalf("expected InvalidArgument, got %v", err)
+		}
+	})
+}

--- a/internal/api/rest/internal_authz.go
+++ b/internal/api/rest/internal_authz.go
@@ -1,44 +1,45 @@
 package rest
 
 import (
-	"context"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
-	"github.com/ihsansolusi/auth7/internal/domain"
+	"github.com/ihsansolusi/auth7/internal/api/grpc/authcheck"
 	"github.com/ihsansolusi/auth7/internal/service/authz"
+	"github.com/ihsansolusi/auth7/internal/store/postgres"
 	"github.com/rs/zerolog"
 )
 
-// authz PDP (Policy Decision Point) — M2M endpoints under /internal/v1 that let
-// other Core7 services (PEPs) ask auth7 whether a user may perform a permission,
-// with the operational-hours time-gate applied. auth7 resolves the user's
-// effective permissions from its own role/permission data (authoritative), so
-// callers pass only identity + the permission being checked.
+// NewAuthCheckGRPCServer builds the gRPC AuthCheckService server (lib7
+// auth7grpc contract) sharing the same decision core as the REST PDP. Returns
+// nil if the store is not a *postgres.Store. Started by cmd/server/start.go.
+func NewAuthCheckGRPCServer(deps ServerDeps) *authcheck.Server {
+	store, ok := deps.Store.(*postgres.Store)
+	if !ok {
+		return nil
+	}
+	checker := authz.NewTimeGatedChecker(deps.TimeWindow, deps.TimeGatedPermissions)
+	return authcheck.NewServer(newAdminUserRoleSvc(store), newAdminRoleSvc(store), checker, deps.Logger)
+}
+
+// authz PDP (Policy Decision Point) — M2M REST endpoints under /internal/v1 that
+// let other Core7 services (PEPs) ask auth7 whether a user may perform a
+// permission, with the operational-hours time-gate applied. auth7 resolves the
+// user's effective permissions from its own role data (authoritative).
 //
-// Transport is REST (the proto AuthCheckService is not yet codegen'd); the
-// decision logic is authz.PermissionChecker, shared with the (future) gRPC path.
-
-// userRolesGetter / rolePermsGetter are the read surface used to resolve a
-// user's effective permissions. Satisfied by the concrete admin service
-// adapters (adminUserRoleSvc, adminRoleSvc).
-type userRolesGetter interface {
-	GetUserRoles(ctx interface{}, userID uuid.UUID) ([]*domain.UserRole, error)
-}
-
-type rolePermsGetter interface {
-	GetPermissions(ctx interface{}, roleID uuid.UUID) ([]*domain.Permission, error)
-}
+// This is the REST surface; the gRPC surface (lib7 auth7grpc contract) lives in
+// internal/api/grpc/authcheck and shares the same authz.PermissionChecker +
+// authz.ResolveAuthContext decision core.
 
 type authzPDPHandler struct {
-	userRoleSvc userRolesGetter
-	roleSvc     rolePermsGetter
+	userRoleSvc authz.UserRolesGetter
+	roleSvc     authz.RolePermsGetter
 	checker     *authz.PermissionChecker
 	logger      zerolog.Logger
 }
 
-func newAuthzPDPHandler(userRoleSvc userRolesGetter, roleSvc rolePermsGetter, checker *authz.PermissionChecker, logger zerolog.Logger) *authzPDPHandler {
+func newAuthzPDPHandler(userRoleSvc authz.UserRolesGetter, roleSvc authz.RolePermsGetter, checker *authz.PermissionChecker, logger zerolog.Logger) *authzPDPHandler {
 	return &authzPDPHandler{userRoleSvc: userRoleSvc, roleSvc: roleSvc, checker: checker, logger: logger}
 }
 
@@ -59,7 +60,6 @@ type pdpCheckRequest struct {
 	ResourceID   string `json:"resource_id"`
 }
 
-// parseIdentity validates the common identity fields shared by both endpoints.
 func (h *authzPDPHandler) parseIdentity(c *gin.Context, req *pdpCheckRequest) (userID, orgID, branchID uuid.UUID, ok bool) {
 	var err error
 	if userID, err = uuid.Parse(req.UserID); err != nil {
@@ -81,46 +81,6 @@ func (h *authzPDPHandler) parseIdentity(c *gin.Context, req *pdpCheckRequest) (u
 	return userID, orgID, branchID, true
 }
 
-// resolveAuthContext loads the user's effective (org-wide + this-branch) active
-// permissions and builds the ABAC AuthContext.
-func (h *authzPDPHandler) resolveAuthContext(ctx context.Context, userID, orgID, branchID uuid.UUID) (*domain.AuthContext, error) {
-	userRoles, err := h.userRoleSvc.GetUserRoles(ctx, userID)
-	if err != nil {
-		return nil, err
-	}
-
-	seen := map[string]bool{}
-	perms := []string{}
-	for _, ur := range userRoles {
-		if ur == nil || ur.OrgID != orgID || !ur.IsActive() {
-			continue
-		}
-		// org-wide (branch_id NULL) always applies; branch-scoped only for this branch.
-		if ur.BranchID != nil && *ur.BranchID != branchID {
-			continue
-		}
-		rolePerms, perr := h.roleSvc.GetPermissions(ctx, ur.RoleID)
-		if perr != nil {
-			return nil, perr
-		}
-		for _, p := range rolePerms {
-			if p == nil || p.Code == "" || seen[p.Code] {
-				continue
-			}
-			seen[p.Code] = true
-			perms = append(perms, p.Code)
-		}
-	}
-
-	return &domain.AuthContext{
-		UserID:      userID,
-		OrgID:       orgID,
-		BranchID:    branchID,
-		Permissions: perms,
-		BranchScope: domain.BranchScopeAssigned,
-	}, nil
-}
-
 func (h *authzPDPHandler) handleCheck(c *gin.Context) {
 	var req pdpCheckRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -132,7 +92,7 @@ func (h *authzPDPHandler) handleCheck(c *gin.Context) {
 		return
 	}
 
-	authCtx, err := h.resolveAuthContext(c.Request.Context(), userID, orgID, branchID)
+	authCtx, err := authz.ResolveAuthContext(c.Request.Context(), h.userRoleSvc, h.roleSvc, userID, orgID, branchID)
 	if err != nil {
 		h.logger.Error().Err(err).Str("user", req.UserID).Msg("pdp resolve auth context failed")
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal_error"})
@@ -165,7 +125,7 @@ func (h *authzPDPHandler) handleCheckDataAccess(c *gin.Context) {
 		return
 	}
 
-	authCtx, err := h.resolveAuthContext(c.Request.Context(), userID, orgID, branchID)
+	authCtx, err := authz.ResolveAuthContext(c.Request.Context(), h.userRoleSvc, h.roleSvc, userID, orgID, branchID)
 	if err != nil {
 		h.logger.Error().Err(err).Str("user", req.UserID).Msg("pdp resolve auth context failed")
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal_error"})
@@ -184,63 +144,4 @@ func (h *authzPDPHandler) handleCheckDataAccess(c *gin.Context) {
 		"reason":      result.Reason,
 		"field_masks": result.FieldMasks,
 	})
-}
-
-// ── no-op authz stores ──────────────────────────────────────────────────────
-// The PDP path pre-populates AuthContext.Permissions and relies on the
-// role-based check + time-gate (+ empty-ABAC = allow-by-default). The enforcer,
-// ABAC policy store, and role store are not exercised, but PermissionChecker /
-// ABACEvaluator require non-nil deps — these satisfy the interfaces.
-
-type noopEnforcer struct{}
-
-func (noopEnforcer) UpdateRolePermissions(context.Context, uuid.UUID, uuid.UUID, string, []string) error {
-	return nil
-}
-func (noopEnforcer) GrantUserRole(context.Context, uuid.UUID, uuid.UUID, string, uuid.UUID) error {
-	return nil
-}
-func (noopEnforcer) RevokeUserRole(context.Context, uuid.UUID, uuid.UUID, string, uuid.UUID) error {
-	return nil
-}
-func (noopEnforcer) Enforce(context.Context, *domain.AuthContext, string, interface{}) (*domain.AuthorizationResult, error) {
-	return &domain.AuthorizationResult{Allowed: true, Reason: "enforcer disabled"}, nil
-}
-func (noopEnforcer) LoadPolicies(context.Context, uuid.UUID) error { return nil }
-
-type noopABACStore struct{}
-
-func (noopABACStore) Create(context.Context, *domain.ABACPolicy) error            { return nil }
-func (noopABACStore) GetByID(context.Context, uuid.UUID, uuid.UUID) (*domain.ABACPolicy, error) {
-	return nil, nil
-}
-func (noopABACStore) Update(context.Context, *domain.ABACPolicy) error            { return nil }
-func (noopABACStore) Delete(context.Context, uuid.UUID, uuid.UUID) error          { return nil }
-func (noopABACStore) ListByOrg(context.Context, uuid.UUID) ([]*domain.ABACPolicy, error) {
-	return nil, nil
-}
-
-type noopRoleStore struct{}
-
-func (noopRoleStore) Create(context.Context, *domain.Role) error                       { return nil }
-func (noopRoleStore) GetByID(context.Context, uuid.UUID, uuid.UUID) (*domain.Role, error) {
-	return nil, nil
-}
-func (noopRoleStore) GetByName(context.Context, uuid.UUID, string) (*domain.Role, error) {
-	return nil, nil
-}
-func (noopRoleStore) Update(context.Context, *domain.Role) error              { return nil }
-func (noopRoleStore) Delete(context.Context, uuid.UUID, uuid.UUID) error      { return nil }
-func (noopRoleStore) ListByOrg(context.Context, uuid.UUID) ([]*domain.Role, error) {
-	return nil, nil
-}
-
-// newTimeGatedChecker builds a PermissionChecker for the PDP: role-based check +
-// (optional) operational-hours time-gate + allow-by-default ABAC.
-func newTimeGatedChecker(tw *authz.TimeWindowEvaluator, gatedPerms []string) *authz.PermissionChecker {
-	checker := authz.NewPermissionChecker(noopEnforcer{}, authz.NewABACEvaluator(noopABACStore{}), noopRoleStore{})
-	if tw != nil {
-		checker = checker.WithTimeGate(tw, gatedPerms)
-	}
-	return checker
 }

--- a/internal/api/rest/internal_authz_test.go
+++ b/internal/api/rest/internal_authz_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/ihsansolusi/auth7/internal/domain"
+	"github.com/ihsansolusi/auth7/internal/service/authz"
 	"github.com/rs/zerolog"
 )
 
@@ -30,7 +31,7 @@ func buildPDPRouter(userRoles []*domain.UserRole, perms map[uuid.UUID][]*domain.
 	r := gin.New()
 	// No time-gate (tw=nil) → role-based decision only; time-gate is covered by
 	// the authz package's own tests.
-	checker := newTimeGatedChecker(nil, nil)
+	checker := authz.NewTimeGatedChecker(nil, nil)
 	h := newAuthzPDPHandler(fakeUserRoles{roles: userRoles}, fakeRolePerms{byRole: perms}, checker, zerolog.Nop())
 	g := r.Group("/internal/v1")
 	h.registerRoutes(g)

--- a/internal/api/rest/internal_routes.go
+++ b/internal/api/rest/internal_routes.go
@@ -7,6 +7,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/ihsansolusi/auth7/internal/api/rest/wfcallback"
 	"github.com/ihsansolusi/auth7/internal/mailer"
+	"github.com/ihsansolusi/auth7/internal/service/authz"
 	"github.com/ihsansolusi/auth7/internal/service/audit"
 	jwtpkg "github.com/ihsansolusi/auth7/internal/service/jwt"
 	"github.com/ihsansolusi/auth7/internal/store/postgres"
@@ -62,7 +63,7 @@ func (s *Server) RegisterInternalV1Routes(r *gin.Engine, m mailer.Mailer) {
 	// authz PDP (Policy Decision Point): M2M decision endpoints for other Core7
 	// services (PEPs) — role-based permission check + operational-hours time-gate.
 	// auth7 resolves the user's effective permissions from its own role data.
-	checker := newTimeGatedChecker(s.deps.TimeWindow, s.deps.TimeGatedPermissions)
+	checker := authz.NewTimeGatedChecker(s.deps.TimeWindow, s.deps.TimeGatedPermissions)
 	newAuthzPDPHandler(newAdminUserRoleSvc(store), newAdminRoleSvc(store), checker, s.deps.Logger).registerRoutes(internalV1)
 }
 

--- a/internal/service/authz/pdp.go
+++ b/internal/service/authz/pdp.go
@@ -1,0 +1,122 @@
+package authz
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"github.com/ihsansolusi/auth7/internal/domain"
+)
+
+// This file centralizes the PDP (Policy Decision Point) composition so the REST
+// and gRPC transports share ONE decision path: identity → effective permissions
+// → PermissionChecker (role-based + operational-hours time-gate + allow-default
+// ABAC).
+
+// UserRolesGetter / RolePermsGetter are the read surface used to resolve a
+// user's effective permissions. Satisfied by the concrete admin service
+// adapters (adminUserRoleSvc, adminRoleSvc). ctx is interface{} to match those
+// adapters' signatures.
+type UserRolesGetter interface {
+	GetUserRoles(ctx interface{}, userID uuid.UUID) ([]*domain.UserRole, error)
+}
+
+type RolePermsGetter interface {
+	GetPermissions(ctx interface{}, roleID uuid.UUID) ([]*domain.Permission, error)
+}
+
+// ResolveAuthContext loads the user's effective (org-wide + this-branch) active
+// permissions and builds the ABAC AuthContext. Org-wide role assignments
+// (branch_id NULL) always apply; branch-scoped ones only for the given branch.
+func ResolveAuthContext(ctx context.Context, ur UserRolesGetter, rp RolePermsGetter, userID, orgID, branchID uuid.UUID) (*domain.AuthContext, error) {
+	userRoles, err := ur.GetUserRoles(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+
+	seen := map[string]bool{}
+	perms := []string{}
+	for _, urole := range userRoles {
+		if urole == nil || urole.OrgID != orgID || !urole.IsActive() {
+			continue
+		}
+		if urole.BranchID != nil && *urole.BranchID != branchID {
+			continue
+		}
+		rolePerms, perr := rp.GetPermissions(ctx, urole.RoleID)
+		if perr != nil {
+			return nil, perr
+		}
+		for _, p := range rolePerms {
+			if p == nil || p.Code == "" || seen[p.Code] {
+				continue
+			}
+			seen[p.Code] = true
+			perms = append(perms, p.Code)
+		}
+	}
+
+	return &domain.AuthContext{
+		UserID:      userID,
+		OrgID:       orgID,
+		BranchID:    branchID,
+		Permissions: perms,
+		BranchScope: domain.BranchScopeAssigned,
+	}, nil
+}
+
+// NewTimeGatedChecker builds a PermissionChecker for the PDP: role-based check +
+// (optional) operational-hours time-gate + allow-by-default ABAC. The enforcer,
+// ABAC policy store, and role store are no-ops (not exercised on this path:
+// permissions are pre-resolved into AuthContext, ABAC has no policies).
+func NewTimeGatedChecker(tw *TimeWindowEvaluator, gatedPerms []string) *PermissionChecker {
+	checker := NewPermissionChecker(noopEnforcer{}, NewABACEvaluator(noopABACStore{}), noopRoleStore{})
+	if tw != nil {
+		checker = checker.WithTimeGate(tw, gatedPerms)
+	}
+	return checker
+}
+
+// ── no-op authz stores (satisfy PermissionChecker/ABACEvaluator deps) ─────────
+
+type noopEnforcer struct{}
+
+func (noopEnforcer) UpdateRolePermissions(context.Context, uuid.UUID, uuid.UUID, string, []string) error {
+	return nil
+}
+func (noopEnforcer) GrantUserRole(context.Context, uuid.UUID, uuid.UUID, string, uuid.UUID) error {
+	return nil
+}
+func (noopEnforcer) RevokeUserRole(context.Context, uuid.UUID, uuid.UUID, string, uuid.UUID) error {
+	return nil
+}
+func (noopEnforcer) Enforce(context.Context, *domain.AuthContext, string, interface{}) (*domain.AuthorizationResult, error) {
+	return &domain.AuthorizationResult{Allowed: true, Reason: "enforcer disabled"}, nil
+}
+func (noopEnforcer) LoadPolicies(context.Context, uuid.UUID) error { return nil }
+
+type noopABACStore struct{}
+
+func (noopABACStore) Create(context.Context, *domain.ABACPolicy) error { return nil }
+func (noopABACStore) GetByID(context.Context, uuid.UUID, uuid.UUID) (*domain.ABACPolicy, error) {
+	return nil, nil
+}
+func (noopABACStore) Update(context.Context, *domain.ABACPolicy) error   { return nil }
+func (noopABACStore) Delete(context.Context, uuid.UUID, uuid.UUID) error { return nil }
+func (noopABACStore) ListByOrg(context.Context, uuid.UUID) ([]*domain.ABACPolicy, error) {
+	return nil, nil
+}
+
+type noopRoleStore struct{}
+
+func (noopRoleStore) Create(context.Context, *domain.Role) error { return nil }
+func (noopRoleStore) GetByID(context.Context, uuid.UUID, uuid.UUID) (*domain.Role, error) {
+	return nil, nil
+}
+func (noopRoleStore) GetByName(context.Context, uuid.UUID, string) (*domain.Role, error) {
+	return nil, nil
+}
+func (noopRoleStore) Update(context.Context, *domain.Role) error        { return nil }
+func (noopRoleStore) Delete(context.Context, uuid.UUID, uuid.UUID) error { return nil }
+func (noopRoleStore) ListByOrg(context.Context, uuid.UUID) ([]*domain.Role, error) {
+	return nil, nil
+}


### PR DESCRIPTION
Closes #167. auth7 serves /auth.v1.AuthCheckService/CheckPermission over gRPC (lib7 auth7grpc JSON-codec contract, no protoc), sharing the PermissionChecker + ResolveAuthContext decision core with the REST PDP (#163). gRPC server gated by AUTH7_GRPC_ADDRESS. Tests green. Enables PEPs (workflow7). Ref core7-devroot#601.